### PR TITLE
DEV-1244: generate and wire the AS-Admin secrets encryption key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -899,6 +899,13 @@ resource "random_password" "r5as_auth_secret" {
   special = false
 }
 
+# Generate the AS-Admin secrets store encryption key. as-admin/as-streams/as-proxy/as-terraform
+# all need the same key to decrypt secrets from the shared Kafka-backed secret store.
+resource "random_id" "r5as_secrets_key" {
+  count       = local.cluster_or_autoscale ? 1 : 0
+  byte_length = 32
+}
+
 resource "random_id" "r5as_conference_secret" {
   count       = local.cluster_or_autoscale ? 1 : 0
   byte_length = 16
@@ -937,6 +944,8 @@ resource "aws_instance" "red5pro_sm" {
           echo "${try(file(var.https_ssl_certificate_cert_path), "")}" > /usr/local/stream-manager/certs/cert.pem
           echo "${try(file(var.https_ssl_certificate_key_path), "")}" > /usr/local/stream-manager/certs/privkey.pem
           chmod 400 /usr/local/stream-manager/certs/privkey.pem
+          echo "${random_id.r5as_secrets_key[0].b64_std}" > /usr/local/stream-manager/keys/r5as-secrets.key
+          chmod 400 /usr/local/stream-manager/keys/r5as-secrets.key
           ############################ .env file #########################################################
           cat >> /usr/local/stream-manager/.env <<- EOM
           KAFKA_CLUSTER_ID=${random_id.kafka_cluster_id[0].b64_std}

--- a/red5pro-installer/docker-compose.yml
+++ b/red5pro-installer/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     deploy:
       replicas: 1
     environment:
+      R5AS_SECRETS_KEY_FILE: ${R5AS_SECRETS_KEY_FILE:-/run/secrets/r5as-secrets.key}
       R5AS_STATE_DIRECTORY: /root/kafka-streams
       R5AS_AUTOSCALE_PARTITIONS: ${R5AS_AUTOSCALE_PARTITIONS:-1}
       R5AS_REPLICATION_FACTOR: ${R5AS_REPLICATION_FACTOR:-1}
@@ -94,6 +95,8 @@ services:
       R5AS_GLOBAL_CONSUMER_MAX_POLL_INTERVAL: ${R5AS_GLOBAL_CONSUMER_MAX_POLL_INTERVAL:-600000}
       R5AS_GLOBAL_CONSUMER_FETCH_MAX_WAIT_TIMEOUT: ${R5AS_GLOBAL_CONSUMER_FETCH_MAX_WAIT_TIMEOUT:-1000}
       R5AS_PRODUCER_REQUEST_TIMEOUT: ${R5AS_PRODUCER_REQUEST_TIMEOUT:-300000}
+    volumes:
+      - ./keys/r5as-secrets.key:/run/secrets/r5as-secrets.key:ro
     labels:
       traefik.http.routers.config-swagger.rule: "PathPrefix(`/swagger-ui`)"
       traefik.http.routers.config-swagger.entrypoints: "web"
@@ -120,6 +123,7 @@ services:
       as-kafka-init:
         condition: service_healthy
     environment:
+      R5AS_SECRETS_KEY_FILE: ${R5AS_SECRETS_KEY_FILE:-/run/secrets/r5as-secrets.key}
       R5AS_STATE_DIRECTORY: /root/kafka-streams
       R5AS_AUTOSCALE_PARTITIONS: ${R5AS_AUTOSCALE_PARTITIONS:-1}
       R5AS_REPLICATION_FACTOR: ${R5AS_REPLICATION_FACTOR:-1}
@@ -130,7 +134,7 @@ services:
       R5AS_SSL_CA_CERTIFICATE: ${KAFKA_SSL_TRUSTSTORE_CERTIFICATES}
       R5AS_SASL_USERNAME: ${KAFKA_CLIENT_USERNAME:-client}
       R5AS_SASL_PASSWORD: ${KAFKA_CLIENT_PASSWORD}
-      R5AS_SASL_ENABLED_MECHANISMS: PLAIN 
+      R5AS_SASL_ENABLED_MECHANISMS: PLAIN
       R5AS_COMMAND_INACTIVITY_GAP_MS: ${R5AS_COMMAND_INACTIVITY_GAP_MS:-10000}
       R5AS_TERRAFORM_PARALLELISM: ${R5AS_TERRAFORM_PARALLELISM:-50}
       R5AS_GROUP_INSTANCE_ID: ${R5AS_GROUP_INSTANCE_ID:-1}
@@ -147,6 +151,7 @@ services:
       TF_VAR_r5p_license_key: ${TF_VAR_r5p_license_key}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./keys/r5as-secrets.key:/run/secrets/r5as-secrets.key:ro
     logging: *logging-config
 
   as-proxy:
@@ -158,6 +163,7 @@ services:
     ports:
       - 9080:8080
     environment:
+      R5AS_SECRETS_KEY_FILE: ${R5AS_SECRETS_KEY_FILE:-/run/secrets/r5as-secrets.key}
       R5AS_REPLICATION_FACTOR: ${R5AS_REPLICATION_FACTOR:-1}
       R5AS_STATE_DIRECTORY: /root/kafka-streams
       R5AS_BOOTSTRAP_SERVERS: ${KAFKA_IP}:9092
@@ -174,6 +180,8 @@ services:
       # R5AS_AUTOSCALE_DOMAIN: ${TRAEFIK_HOST:-localhost}
       R5AS_PROXY_HTTP_REQUEST_TIMEOUT_S: ${R5AS_PROXY_HTTP_REQUEST_TIMEOUT_S:-60}
       R5AS_GROUP_INSTANCE_ID: ${R5AS_GROUP_INSTANCE_ID:-1}
+    volumes:
+      - ./keys/r5as-secrets.key:/run/secrets/r5as-secrets.key:ro
     labels:
       traefik.enable: true
       traefik.http.routers.asproxy.rule: PathPrefix(`/as/v1/proxy`)
@@ -314,6 +322,7 @@ services:
       retries: 18  # 3 mins
       start_period: 300s  # grace period, not minimum
     environment:
+      R5AS_SECRETS_KEY_FILE: ${R5AS_SECRETS_KEY_FILE:-/run/secrets/r5as-secrets.key}
       R5AS_AUTH_SECRET: ${R5AS_AUTH_SECRET:?R5AS_AUTH_SECRET is not set}
       R5AS_AUTH_JWT_TTL_MINUTES: ${R5AS_AUTH_JWT_TTL_MINUTES:-800}
       R5AS_STATE_DIRECTORY: /root/kafka-streams
@@ -327,7 +336,7 @@ services:
       R5AS_SSL_CA_CERTIFICATE: ${KAFKA_SSL_TRUSTSTORE_CERTIFICATES}
       R5AS_SASL_USERNAME: ${KAFKA_CLIENT_USERNAME:-client}
       R5AS_SASL_PASSWORD: ${KAFKA_CLIENT_PASSWORD}
-      R5AS_SASL_ENABLED_MECHANISMS: PLAIN 
+      R5AS_SASL_ENABLED_MECHANISMS: PLAIN
       R5AS_RESTREAMER_REDISTRIBUTE_SECONDS: ${R5AS_RESTREAMER_REDISTRIBUTE_SECONDS:-60}
       R5AS_STREAM_TIMEOUT: ${R5AS_STREAM_TIMEOUT:-30}
 
@@ -349,6 +358,8 @@ services:
       R5AS_PRODUCER_LINGER_MS: ${R5AS_PRODUCER_LINGER_MS:-50}
       R5AS_PRODUCER_TRANSACTION_TIMEOUT: ${R5AS_PRODUCER_TRANSACTION_TIMEOUT:-900000}
       R5AS_GROUP_INSTANCE_ID: ${R5AS_GROUP_INSTANCE_ID:-1}
+    volumes:
+      - ./keys/r5as-secrets.key:/run/secrets/r5as-secrets.key:ro
     labels:
       prometheus.scrape: true
       prometheus.path: /streams/metrics


### PR DESCRIPTION
## Summary
- `as-admin`/`as-streams`/`as-proxy`/`as-terraform` all need `R5AS_SECRETS_KEY_FILE` (default `/run/secrets/r5as-secrets.key`) to encrypt/decrypt secrets in the shared Kafka-backed secret store. This module predates that feature, so `docker-compose.yml` did not mount the key file or set the env var at all, and Terraform never generated one.
- Adds `random_id.r5as_secrets_key` (byte_length = 32, matching `openssl rand -base64 32`), written to `stream-manager/keys/r5as-secrets.key` during SM provisioning - same pattern already used for `random_password.r5as_auth_secret`.
- For `type=autoscale`, the key is baked into the AMI the same way `R5AS_AUTH_SECRET` already is (`aws_ami_from_instance` depends on the provisioned instance), so every SM launched from the autoscaling group shares the same key.
- Wires `R5AS_SECRETS_KEY_FILE` + the `./keys/r5as-secrets.key` volume mount into `as-admin`, `as-terraform`, `as-proxy`, and `as-streams` in `red5pro-installer/docker-compose.yml`, matching the wiring already shipped in `red5pro-plugins`' `docker-compose-base.yml` (`feature/AUTO-677`).

## Test plan
- [x] `terraform validate` passes
- [ ] Deploy a `cluster`/`autoscale` SM and confirm `as-admin`/`as-streams`/`as-proxy`/`as-terraform` start healthy and can resolve a secret (e.g. `clusterPassword`)